### PR TITLE
Remove 3DfindIT addon (no longer maintained)

### DIFF
--- a/Data/Index.json
+++ b/Data/Index.json
@@ -13,15 +13,6 @@
       "curated": true
     }
   ],
-  "3DfindIT": [
-    {
-      "repository": "https://github.com/cadenasgmbh/3dfindit-freecad-integration",
-      "git_ref": "master",
-      "branch_display_name": "master",
-      "zip_url": "https://github.com/cadenasgmbh/3dfindit-freecad-integration/archive/refs/heads/master.zip",
-      "curated": true
-    }
-  ],
   "A2plus": [
     {
       "repository": "https://github.com/kbwbe/A2plus",


### PR DESCRIPTION
The 3DfindIT addon (cadenasgmbh/3dfindit-freecad-integration) is no longer maintained and is incompatible with FreeCAD ≥ 1.0. Details in cadenasgmbh/3dfindit-freecad-integration#21.

The upstream repository has been archived and a deprecation notice has been added to its README. Please remove the entry from the index so users no longer see (and try to install) a non-functional addon.