### PR TITLE
Index: freecad-mcp-bridge v0.1.14

### DIFF
--- a/Data/Index.json
+++ b/Data/Index.json
@@ -563,6 +563,14 @@
       "curated": true
     }
   ],
+  "freecad-mcp-bridge": [
+    {
+      "repository": "https://github.com/CREATeNG/freecad-mcp-bridge",
+      "git_ref": "v0.1.14",
+      "branch_display_name": "v0.1.14",
+      "zip_url": "https://github.com/CREATeNG/freecad-mcp-bridge/archive/refs/tags/v0.1.14.zip"
+    }
+  ],
   "freecad.gears": [
     {
       "repository": "https://github.com/looooo/freecad.gears",

--- a/Data/Index.json
+++ b/Data/Index.json
@@ -568,7 +568,8 @@
       "repository": "https://github.com/CREATeNG/freecad-mcp-bridge",
       "git_ref": "v0.1.14",
       "branch_display_name": "v0.1.14",
-      "zip_url": "https://github.com/CREATeNG/freecad-mcp-bridge/archive/refs/tags/v0.1.14.zip"
+      "zip_url": "https://github.com/CREATeNG/freecad-mcp-bridge/archive/refs/tags/v0.1.14.zip",
+      "curated": false
     }
   ],
   "freecad.gears": [


### PR DESCRIPTION
Automated Index update from [CREATeNG/freecad-mcp-bridge](https://github.com/CREATeNG/freecad-mcp-bridge) release `v0.1.14`.

- Entry: `freecad-mcp-bridge`
- Updates `git_ref`, `branch_display_name`, and `zip_url`

**Repository:** https://github.com/CREATeNG/freecad-mcp-bridge
**Tag / git_ref:** `v0.1.14`
**Zip URL:** https://github.com/CREATeNG/freecad-mcp-bridge/archive/refs/tags/v0.1.14.zip

Relates to #70. Thanks for review — happy to adjust anything needed, including `curated`.