### PR TITLE
Namechange in xml, ("GearWorkBench", not "Gear Designer")

### DIFF
--- a/Data/Index.json
+++ b/Data/Index.json
@@ -745,8 +745,8 @@
     {
       "repository": "https://github.com/iplayfast/GearWorkBench",
       "git_ref": "1.3",
-      "branch_display_name": "1.3",
-      "zip_url": "https://github.com/iplayfast/GearWorkBench/archive/refs/tags/1.3.zip",
+      "branch_display_name": "1.3.1",
+      "zip_url": "https://github.com/iplayfast/GearWorkBench/archive/refs/tags/1.3.1.zip",
       "curated": false
     }
   ],


### PR DESCRIPTION
In the list it's called Gear Designer, whereas everywhere else it's called GearWorkBench. Updated so all is hopefully consistent. 