### PR TITLE
Add sparse_cache to index: requires FreeCAD/AddonManager#467

### DIFF
--- a/Data/Index.json
+++ b/Data/Index.json
@@ -605,7 +605,8 @@
       "git_ref": "main",
       "branch_display_name": "main",
       "zip_url": "https://github.com/Reqrefusion/FreeCAD-Documentation-html/archive/refs/heads/main.zip",
-      "curated": true
+      "curated": true,
+      "sparse_cache": true
     }
   ],
   "Freecad-Built-in-themes-beta": [
@@ -899,7 +900,8 @@
       "git_ref": "master",
       "branch_display_name": "master",
       "zip_url": "https://github.com/FreeCAD/FreeCAD-library/archive/refs/heads/master.zip",
-      "curated": true
+      "curated": true,
+      "sparse_cache": true
     }
   ],
   "Lithophane": [
@@ -1042,7 +1044,8 @@
       "git_ref": "main",
       "branch_display_name": "main",
       "zip_url": "https://github.com/FreeCAD/FreeCAD-documentation/archive/refs/heads/main.zip",
-      "curated": true
+      "curated": true,
+      "sparse_cache": true
     }
   ],
   "Ondsel-Lens": [


### PR DESCRIPTION
This adds the new "sparse_cache" field to the Index, telling the cache that this is a large addon that should be cloned sparsely (metadata files only) and then downloaded by the user directly from its git repo. This allows *updates* to use git later on, saving a huge amount of download time.

Note that FreeCAD/AddonManager#467 must merge first.